### PR TITLE
feat: add client_c to test mutual friends

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,3 +41,7 @@ path = "src/client_a.rs"
 [[bin]]
 name = "client_b"
 path = "src/client_b.rs"
+
+[[bin]]
+name = "client_c"
+path = "src/client_c.rs"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -12,7 +12,7 @@ const DCL_PROTOCOL_REPO_URL: &str =
     "https://api.github.com/repos/decentraland/protocol/contents/proto/decentraland";
 const FRIENDSHIP_PROTO_PATH: &str = "/social/friendships/friendships.proto";
 /// Modify this value to update the proto version, it is the commit sha from protocol repo used for downloading the proto file
-const FRIENDSHIPS_PROTOCOL_VERSION: &str = "6fe3e1bbc29baaab95d8844782a3baf41e61c776";
+const FRIENDSHIPS_PROTOCOL_VERSION: &str = "c14d71c3f1f0393369b65667dddd6c59136f45e5";
 const EXTERNAL_DEFINITIONS_FOLDER: &str = "ext-proto";
 const EXT_FRIENDSHIPS_PROTO_FILE: &str = "ext-proto/friendships.proto";
 

--- a/rust/credentials.example.json
+++ b/rust/credentials.example.json
@@ -2,12 +2,12 @@
   "users":
   [
     {
-      "address": "",
-      "token": ""
+      "social_user_id": "",
+      "access_token": ""
     },
     {
-      "address": "",
-      "token": ""
+      "social_user_id": "",
+      "access_token": ""
     }
   ]
 }

--- a/rust/src/client_a.rs
+++ b/rust/src/client_a.rs
@@ -13,9 +13,9 @@ const RECONNECT_DELAY: u64 = 10; // seconds
 #[tokio::main]
 async fn main() {
     // Auth Users
-    let (user_a, user_b) = load_users().await;
+    let [user_a, user_b, _] = load_users().await;
 
-    let host = "ws://127.0.0.1:5000";
+    let host = "ws://127.0.0.1:8085";
 
     loop {
         match WebSocketClient::connect(host).await {

--- a/rust/src/client_b.rs
+++ b/rust/src/client_b.rs
@@ -13,9 +13,9 @@ const RECONNECT_DELAY: u64 = 10; // seconds
 #[tokio::main]
 async fn main() {
     // Auth Users
-    let (user_a, user_b) = load_users().await;
+    let [user_a, user_b, _] = load_users().await;
 
-    let host = "ws://127.0.0.1:5001";
+    let host = "ws://127.0.0.1:8085";
 
     loop {
         match WebSocketClient::connect(host).await {

--- a/rust/src/client_c.rs
+++ b/rust/src/client_c.rs
@@ -1,0 +1,105 @@
+use dcl_rpc::transports::web_sockets::tungstenite::WebSocketClient;
+use dcl_rpc::{
+    client::RpcClient,
+    transports::web_sockets::{tungstenite::TungsteniteWebSocket, WebSocketTransport},
+};
+use social_client::{FriendshipsServiceClientDefinition, MutualFriendsPayload, User, Payload};
+use social_client::credentials::AuthUser;
+use social_client::friendship_procedures::Flow;
+use social_client::{credentials::load_users, FriendshipsServiceClient};
+
+type Transport = WebSocketTransport<TungsteniteWebSocket, ()>;
+
+const RECONNECT_DELAY: u64 = 10; // seconds
+
+#[tokio::main]
+async fn main() {
+    // Auth Users
+    let [user_a, user_b, user_c] = load_users().await;
+
+    let host = "ws://127.0.0.1:8085";
+
+    match WebSocketClient::connect(host).await {
+        Ok(client_connection) => {
+            let client_transport = WebSocketTransport::new(client_connection.clone());
+
+            let mut client = RpcClient::new(client_transport).await.unwrap();
+
+            let port = client.create_port("friendships").await.unwrap();
+
+            let module = port
+                .load_module::<FriendshipsServiceClient<Transport>>("FriendshipsService")
+                .await
+                .unwrap();
+
+            println!("C -> B: send request");
+            let request = Flow::Request;
+            request
+                .execute_event(&module, user_c.clone(), user_b.clone())
+                .await;
+
+            println!("Waiting for Matrix to update the status...");
+            tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
+
+            println!("B -> C: accept request");
+            let accept = Flow::Accept;
+            accept
+                .execute_event(&module, user_c.clone(), user_b.clone())
+                .await;
+
+            println!("A -> C: send request");
+            let request = Flow::Request;
+            request
+                .execute_event(&module, user_a.clone(), user_c.clone())
+                .await;
+
+            println!("Waiting for Matrix to update the status...");
+            tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
+            
+            println!("C -> A: accept request");
+            let accept = Flow::Accept;
+            accept
+                .execute_event(&module, user_a.clone(), user_c.clone())
+                .await;
+
+            println!("Waiting for Matrix to update the status...");
+            tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
+
+            get_mutual_friends(&module, &user_a, &user_c).await;
+        }
+        _ => {
+            println!("Failed to connect, retrying in {RECONNECT_DELAY} seconds...");
+            tokio::time::sleep(tokio::time::Duration::from_secs(RECONNECT_DELAY)).await;
+        }
+    }
+    
+}
+
+
+/// Get and print the friends of the given user using the given module client.
+pub async fn get_mutual_friends(module: &FriendshipsServiceClient<Transport>, user: &AuthUser, other_user: &AuthUser) {
+    let friends_response = module
+        .get_mutual_friends(MutualFriendsPayload {
+            user: Some(User{address: other_user.clone().address}),
+            auth_token: Some(Payload{synapse_token: Some(user.clone().token)}),
+        })
+        .await;
+    match friends_response {
+        Ok(mut friends_response) => {
+            println!(
+                "> Server Streams > Response > GetMutualFriendsResponse for {:?}",
+                &user.clone().address[user.address.len() - 4..]
+            );
+            while let Some(friend) = friends_response.next().await {
+                println!(
+                    "> Server Streams > Response > GetMutualFriendsResponse for {:?}: {:?}",
+                    &user.clone().address[user.address.len() - 4..],
+                    friend.response
+                )
+            }
+        }
+        Err(err) => {
+            panic!("{err:?}")
+        }
+    }
+}

--- a/rust/src/credentials.rs
+++ b/rust/src/credentials.rs
@@ -16,26 +16,29 @@ pub struct AuthUser {
     pub token: String,
 }
 
-pub async fn load_users() -> (AuthUser, AuthUser) {
+pub async fn load_users() -> [AuthUser; 3] {
     // Read token from file
-    match std::fs::read_to_string("credentials.json") {
+    match std::fs::read_to_string("credentials.zone.json") {
         Ok(it) => {
             let users = serde_json::from_str::<serde_json::Value>(&it).unwrap();
             let users = &users["users"];
 
             let user_a = extract_user(&users[0], "A").await;
             let user_b = extract_user(&users[1], "B").await;
+            let user_c = extract_user(&users[2], "C").await;
 
-            (user_a, user_b)
+            [user_a, user_b, user_c]
         }
         Err(_) => {
             // If missing read from stdin
             let token_user_a = get_input("Enter Token for User A: ").await.unwrap();
             let token_user_b = get_input("Enter Token for User B: ").await.unwrap();
+            let token_user_c = get_input("Enter Token for User C: ").await.unwrap();
             let user_a_address = get_input("Enter Address for User A: ").await.unwrap();
             let user_b_address = get_input("Enter Address for User B: ").await.unwrap();
+            let user_c_address = get_input("Enter Address for User C: ").await.unwrap();
 
-            (
+            [
                 AuthUser {
                     address: user_a_address,
                     token: token_user_a,
@@ -44,20 +47,24 @@ pub async fn load_users() -> (AuthUser, AuthUser) {
                     address: user_b_address,
                     token: token_user_b,
                 },
-            )
+                AuthUser {
+                    address: user_c_address,
+                    token: token_user_c,
+                },
+            ]
         }
     }
 }
 
 pub async fn extract_user(user: &serde_json::Value, user_id: &str) -> AuthUser {
-    let address = match user["address"].as_str() {
+    let address = match user["social_user_id"].as_str() {
         Some(address) => address.to_string(),
         None => {
             let message = format!("Enter address for User {user_id}");
             get_input(&message).await.unwrap()
         }
     };
-    let token = match user["token"].as_str() {
+    let token = match user["access_token"].as_str() {
         Some(token) => token.to_string(),
         None => {
             let message = format!("Enter token for User {user_id}");

--- a/rust/src/friendship_events_listener.rs
+++ b/rust/src/friendship_events_listener.rs
@@ -11,14 +11,14 @@ type Transport = WebSocketTransport<TungsteniteWebSocket, ()>;
 #[tokio::main]
 async fn main() {
     // Auth Users
-    let (user_a, user_b) = load_users().await;
+    let [user_a, user_b, _] = load_users().await;
 
     let which_a = format!("USER_A_{}", &user_a.address[user_a.address.len() - 4..]);
     let which_b = format!("USER_B_{}", &user_b.address[user_b.address.len() - 4..]);
 
     // Hosts
-    let host_a = "ws://localhost:5000";
-    let host_b = "ws://localhost:5001";
+    let host_a = "ws://localhost:8085";
+    let host_b = "ws://localhost:8085";
 
     let handle_a = tokio::spawn(async move {
         loop {

--- a/rust/src/friendship_procedures_executor.rs
+++ b/rust/src/friendship_procedures_executor.rs
@@ -23,7 +23,7 @@ async fn main() {
     };
 
     // Auth Users
-    let (user_a, user_b) = load_users().await;
+    let [user_a, user_b, _] = load_users().await;
 
     let host_a = "ws://127.0.0.1:8085";
     let host_b = "ws://127.0.0.1:8086";


### PR DESCRIPTION
Changes:
- Refactor `load_users` to handle 3 users
- Change the format of `credentials.json` to be the same as the matrix response
- Use 8085 port for Social Service
- Add client_c that tests the get mutual friends message